### PR TITLE
Add dark mode support, jpeg quality option

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,18 @@ Type: `Number`
 
 Page scale number. Default value `1`.
 
+##### options.darkMode
+
+Type: `Boolean`
+
+Whether or not to tell the browser to use dark mode. Default value `false`.
+
+##### options.quality
+
+Type: `Number`
+
+JPEG image quality (0-100). Default value `60`.
+
 ## Usage (CLI)
 
 ```bash

--- a/bin/tweet-shot.js
+++ b/bin/tweet-shot.js
@@ -12,6 +12,8 @@ program
     .option('--dest <destination-path>', 'Set destination directory')
     .option('--proxy <proxy-url>', 'Set proxy url')
     .option('--scale <scale-number>', 'Set scale')
+    .option('--quality <quality-number>', 'Set quality', parseInt)
+    .option('--dark-mode', 'Set dark mode in browser')
     .parse(process.argv);
 
 const spinner = (text) => {
@@ -25,14 +27,20 @@ const spinner = (text) => {
 };
 
 const run = async () => {
-    const { url, dest, proxy, scale } = program;
+    const { url, dest, proxy, scale, quality, darkMode } = program;
 
     const stepName = `[tweet-shot] downloading ${url}`;
     const step = spinner(`${stepName}...`);
 
     step.start();
     try {
-        await tweetShot(url, { dest, proxy, scale });
+        await tweetShot(url, {
+            dest,
+            proxy,
+            scale,
+            quality,
+            darkMode,
+        });
         step.stop();
         spinner(stepName).succeed();
     } catch (e) {

--- a/src/tweet-show.d.ts
+++ b/src/tweet-show.d.ts
@@ -13,6 +13,10 @@ export interface Options {
 
     /** 设置页面缩放值，默认为 `1` */
     scale?: number;
+
+    quality?: number;
+
+    darkMode?: boolean;
 }
 
 export interface Result {


### PR DESCRIPTION
- [x] Update to allow dark mode screen capture.
    - [x] Update readme type docs
    - [x] Update comment docs
    - [x] Update ts file
    - [x] Update CLI parsing
    - [x] Append string for output files to distinguish between light and dark mode.
    - [x] Add new option to tweet-shot
    - [x] Update puppeteer page to enable light/dark mode setting.
- [x] Update to allow specifying JPG quality.
    - [x] Update readme type docs
    - [x] Update comment docs
    - [x] Update ts file
    - [x] Update CLI parsing
    - [x] Add new option to tweet-shot
    - [x] Pass option into screenshot call

`tweet-shot --url https://twitter.com/Diablohu/status/1092414659057967104 --quality 100`
![Diablohu-1092414659057967104_](https://user-images.githubusercontent.com/122682/99695933-26213380-2a5c-11eb-8e54-af108f5d70a1.jpg)
` https://twitter.com/Diablohu/status/1092414659057967104 --quality 100 --dark-mode`
![Diablohu-1092414659057967104__dark](https://user-images.githubusercontent.com/122682/99695941-291c2400-2a5c-11eb-9019-474e010a581c.jpg)

